### PR TITLE
Update Gost Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,9 @@
-FROM debian:oldstable-slim
-MAINTAINER mixool0204@gmail.com
+FROM golang:1.9-alpine as builder
+RUN apk add --update git
+RUN CGO_ENABLED=0 GOOS=linux go get github.com/ginuerzh/gost/cmd/gost
 
-RUN apt-get update \
-    && apt-get install -y wget \
-    && wget --no-check-certificate https://github.com/ginuerzh/gost/releases/download/v2.4-dev/gost_2.4-dev20170303_linux_amd64.tar.gz \
-    && tar -xzf gost_2.4-dev20170303_linux_amd64.tar.gz \
-    && mv gost_2.4-dev20170303_linux_amd64/gost /root/ \
-    && apt-get remove wget -y \
-    && apt-get autoremove -y \
-    && apt-get clean \
-    && rm -rf gost_2.4-dev20170303_linux_amd64.tar.gz  /var/lib/apt/lists/*
 
-ENTRYPOINT ["/root/gost"]
+FROM scratch
+LABEL maintainer="Tonin R. Bolzan <tonin@bolzan.io>, Mcl <mixool0204@gmail.com>"
+COPY --from=builder /go/bin/gost /gost
+ENTRYPOINT ["/gost"]


### PR DESCRIPTION
Update to last version and create a scratch images with very low size.
Docker 17.05 required to build